### PR TITLE
change the default healthy status to true

### DIFF
--- a/healthchecker/src/healthcheck.rs
+++ b/healthchecker/src/healthcheck.rs
@@ -72,7 +72,7 @@ impl Member {
         Member {
             host: host.clone(),
             ip: resolved_v4,
-            healthy: false,
+            healthy: true,
             cancel: false,
         }
     }


### PR DESCRIPTION
Pool members will be healthy until shown otherwise for dns load balancing